### PR TITLE
Separate public tmpnb url from internal tmpnb url

### DIFF
--- a/plugin_tests/ythub_test.py
+++ b/plugin_tests/ythub_test.py
@@ -175,15 +175,24 @@ class YtHubTestCase(base.TestCase):
             'admin': True
         }
         user = self.model('user').createUser(**adminDef)
+        resp = self.request(
+                path='/assetstore', method='POST', user=user,
+                params={'type': 0, 'name': 'test', 'root': '/tmp/girder'})
+        self.assertStatusOk(resp)
+        assetstore = resp.json
+
         c1 = self.model('collection').createCollection('c1', user)
         f1 = self.model('folder').createFolder(
             c1, 'f1', parentType='collection')
         i1 = self.model('item').createItem('i1', user, f1)
         i2 = self.model('item').createItem('i2', user, f1)
-        assetstore = {'_id': 0}
         fl1 = self.model('file').createFile(user, i1, 'foo1', 7, assetstore)
         fl2 = self.model('file').createFile(user, i1, 'foo2', 13, assetstore)
         fl3 = self.model('file').createFile(user, i2, 'foo3', 19, assetstore)
+        for ofile in (fl1, fl2, fl3):
+            ofile['path'] = '/nonexistent/path/%s' % ofile['name']
+            ofile = self.model('file').save(ofile)
+
         f2 = self.model('folder').createFolder(
             f1, 'f2', parentType='folder')
         i3 = self.model('item').createItem('i3', user, f2)

--- a/plugin_tests/ythub_test.py
+++ b/plugin_tests/ythub_test.py
@@ -265,3 +265,11 @@ class YtHubTestCase(base.TestCase):
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['url'], 'https://tmpnb.null')
         self.assertEqual(resp.json['pubkey'], pubkey)
+
+        resp = self.request('/system/setting', user=admin, method='PUT',
+                            params={'key': PluginSettings.REDIRECT_URL,
+                                    'value': 'https://blah.null'})
+        self.assertStatusOk(resp)
+        resp = self.request(path='/ythub', method='GET')
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json['url'], 'https://blah.null')

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -74,6 +74,12 @@ def validateTmpNbUrl(doc):
             'TmpNB URL must not be empty.', 'value')
 
 
+@setting_utilities.validator(PluginSettings.REDIRECT_URL)
+def validateTmpNbRedirectUrl(doc):
+    if not doc['value']:
+        return ''
+
+
 @setting_utilities.validator(PluginSettings.CULLING_PERIOD)
 def validateCullingPeriod(doc):
     if not doc['value']:

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -5,6 +5,7 @@ import cherrypy
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
+import six
 
 from girder import events, logger
 from girder.models.model_base import ValidationException
@@ -27,10 +28,9 @@ def validateHubPrivKey(doc):
     if not doc['value']:
         raise ValidationException(
             'PRIV_KEY must not be empty.', 'value')
-    try:
-        key = doc['value'].encode('utf8')
-    except AttributeError:
-        key = doc['value']
+    key = doc['value']
+    if isinstance(key, six.string_types):
+        key = key.encode('utf-8')
     try:
         serialization.load_pem_private_key(
             key, password=None, backend=default_backend()
@@ -51,10 +51,9 @@ def validateHubPubKey(doc):
     if not doc['value']:
         raise ValidationException(
             'PUB_KEY must not be empty.', 'value')
-    try:
-        key = doc['value'].encode('utf8')
-    except AttributeError:
-        key = doc['value']
+    key = doc['value']
+    if isinstance(key, six.string_types):
+        key = key.encode('utf-8')
     try:
         serialization.load_pem_public_key(
             key, backend=default_backend()

--- a/server/constants.py
+++ b/server/constants.py
@@ -10,7 +10,8 @@ API_VERSION = '1.1'
 class PluginSettings:
     CULLING_PERIOD = 'ythub.culling_period'
     CULLING_FREQUENCY = 'ythub.culling_frequency'
-    TMPNB_URL = 'ythub.tmpnb_url'
+    TMPNB_URL = 'ythub.tmpnb_internal_url'
+    REDIRECT_URL = 'ythub.tmpnb_redirect_url'
     HUB_PRIV_KEY = 'ythub.priv_key'
     HUB_PUB_KEY = 'ythub.pub_key'
 

--- a/server/rest/ythub.py
+++ b/server/rest/ythub.py
@@ -40,7 +40,7 @@ class ytHub(Resource):
             encoding=serialization.Encoding.PEM,
             format=serialization.PrivateFormat.TraditionalOpenSSL,
             encryption_algorithm=serialization.NoEncryption()
-        )
+        ).decode('utf8')
         self.model('setting').set(PluginSettings.HUB_PUB_KEY, pubkey_pem)
         self.model('setting').set(PluginSettings.HUB_PRIV_KEY, privkey_pem)
         return {PluginSettings.HUB_PUB_KEY: pubkey_pem,
@@ -52,7 +52,10 @@ class ytHub(Resource):
     )
     def get_ythub_url(self, params):
         setting = self.model('setting')
-        return {'url': setting.get(PluginSettings.TMPNB_URL),
+        url = setting.get(PluginSettings.REDIRECT_URL)
+        if not url:
+            url = setting.get(PluginSettings.TMPNB_URL)
+        return {'url': url,
                 'pubkey': setting.get(PluginSettings.HUB_PUB_KEY)}
 
     @access.public

--- a/web_client/templates/configView.pug
+++ b/web_client/templates/configView.pug
@@ -1,19 +1,22 @@
 .g-config-breadcrumb-container
 form#g-ythub-config-form(role="form")
   .form-group
-    label.control-label(for="ythub_tmpnb") tmpnb URL
-    input.input-sm.form-control#ythub_tmpnb(
+    label.control-label(for="ythub-tmpnb-internal-url") tmpnb internal URL
+    input.input-sm.form-control#ythub-tmpnb-internal-url(
+      type="text", placeholder="Temporary notebook redirect URL (if different than above)")
+    label.control-label(for="ythub-tmpnb-redirect-url") tmpnb redirect URL
+    input.input-sm.form-control#ythub-tmpnb-redirect-url(
       type="text", placeholder="Temporary notebook server's URL")
-    label.control-label(for="ythub_culling") How long can a notebook be inactive before it's removed (in hours)
-    input.input-sm.form-control#ythub_culling(
+    label.control-label(for="#ythub-culling-period") How long can a notebook be inactive before it's removed (in hours)
+    input.input-sm.form-control#ythub-culling-period(
       type="text", placeholder="Maximum inactivity period (hours) before notebook is deleted")
-    label.control-label(for="ythub_cullingfq") How often to check for inactive notebooks (in hours)
-    input.input-sm.form-control#ythub_cullingfq(
+    label.control-label(for="ythub-culling-frequency") How often to check for inactive notebooks (in hours)
+    input.input-sm.form-control#ythub-culling-frequency(
       type="text", placeholder="Culling check frequency in hours")
-    label.control-label(for="ythub_priv_key") yt Hub's private RSA key
-    textarea#ythub_priv_key.form-control= privkey
-    label.control-label(for="ythub_pub_key") yt Hub's public RSA key
-    textarea#ythub_pub_key.form-control= pubkey
+    label.control-label(for="ythub-priv-key") yt Hub's private RSA key
+    textarea#ythub-priv-key.form-control= privkey
+    label.control-label(for="ythub-pub-key") yt Hub's public RSA key
+    textarea#ythub-pub-key.form-control= pubkey
 
   p#g-ythub-error-message.g-validation-failed-message
   button.g-generate-key.btn.btn-small.btn-primary(title="Generate Key")


### PR DESCRIPTION
In case when girder communicates with a proxy over a private network (via tmpnb_url), we need to use a different url for accessing notebooks.